### PR TITLE
Remove incorrect zip instructions for LeaveMessageFlow.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,6 @@ Goto Line 11 and set <FLOW NAME> to something unique using your user name (lette
 
 ![](images/configure-flow-json.png)
 
-Save and close CallBot.json
-
-Compress CallBot.json so that it is contained within a .zip file.
-
 
 ### Create Amazon Connect Flow
 


### PR DESCRIPTION
There are some incorrect instructions on the LeaveMessageFlow.json part as it asks to compress the CallBot.json file. We're addressing the wrong file, and the correct LeaveMessageFlow.json file doesn't need compression when uploading.